### PR TITLE
Add resolve option to only allow own properties

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -16,7 +16,7 @@ import {isClass} from './utils';
  */
 export function resolvePath(this: any, target: any, path: PathInput, options?: IPathOptions): IPathResult {
     const chain = typeof path === 'string' ? path.indexOf('.') === -1 ? [path] : path.split('.') : path;
-    const len = chain.length, ignoreFunctions = options && options.ignoreFunctions;
+    const len = chain.length, ignoreFunctions = options && options.ignoreFunctions, ownProperties = options && options.ownProperties;
     let value, isThis, i = 0, exists = true, scope = target;
     for (i; i < len; i++) {
         const name = chain[i];
@@ -37,7 +37,8 @@ export function resolvePath(this: any, target: any, path: PathInput, options?: I
             }
             break;
         }
-        value = isThis ? target : target[name];
+        let isOwnProperty = true;
+        value = isThis ? target : !ownProperties || (isOwnProperty = target?.hasOwnProperty(name)) ? target[name] : undefined;
         while (!ignoreFunctions && typeof value === 'function' && !isClass(value)) {
             value = value.call(target);
         }
@@ -45,7 +46,7 @@ export function resolvePath(this: any, target: any, path: PathInput, options?: I
             i++;
             if (value === undefined && i === len) {
                 const obj = typeof target === 'object' ? target : target.constructor.prototype;
-                exists = name in obj;
+                exists = !ownProperties ? name in obj : isOwnProperty;
             }
             break;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,12 @@ export interface IPathOptions {
      *  - Invoking functions by the parser may be considered unsafe in certain context.
      */
     ignoreFunctions?: boolean;
+
+    /**
+     * By default, the parser will access inherited properties.
+     * This option overrides the default behaviour to disallow accessing inherited properties.
+     */
+    ownProperties?: boolean;
 }
 
 /**

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -317,6 +317,34 @@ describe('with options', () => {
             });
         });
     });
+
+    describe('when ownProperties is set', () => {
+        const tst = {value: 123};
+        Object.setPrototypeOf(tst, {inherited: 321});
+        const target = {tst};
+
+        it('must not resolve inherited properties', () => {
+            expect(resolve(target, 'tst.inherited', {ownProperties: true})).to.eql({
+                chain: ['tst', 'inherited'],
+                scope: target,
+                options: {ownProperties: true},
+                idx: 1,
+                exists: false,
+                value: undefined
+            });
+        });
+
+        it('must resolve for own properties', () => {
+            expect(resolve(target, 'tst.value', {ownProperties: true})).to.eql({
+                chain: ['tst', 'value'],
+                scope: target,
+                options: {ownProperties: true},
+                idx: 1,
+                exists: true,
+                value: 123
+            });
+        });
+    });
 });
 
 describe('for array indexes', () => {


### PR DESCRIPTION
Implemented need for our own use to disallow access to inherited properties.