### PR TITLE
Add support for negative array indexes

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -39,7 +39,11 @@ export function resolvePath(this: any, target: any, path: PathInput, options?: I
             break;
         }
         let isOwnProperty = true;
-        value = isThis ? target : !ownProperties || (isOwnProperty = target?.hasOwnProperty(name)) ? target[name] : undefined;
+        if(Array.isArray(target)) {
+            value = target.at(Number(name));
+        } else {
+            value = isThis ? target : !ownProperties || (isOwnProperty = target?.hasOwnProperty(name)) ? target[name] : undefined;
+        }
         while (!ignoreFunctions && typeof value === 'function' && !isClass(value)) {
             value = value.call(target);
         }
@@ -77,7 +81,7 @@ export function resolvePath(this: any, target: any, path: PathInput, options?: I
  * Valid JavaScript property path.
  */
 export function tokenizePath(path: string): string[] {
-    const res = [], reg = /\[\s*(\d+)(?=\s*])|\[\s*(["'])((?:\\.|(?!\2).)*)\2\s*]|[\w$]+/g;
+    const res = [], reg = /\[\s*([-]*\d+)(?=\s*])|\[\s*(["'])((?:\\.|(?!\2).)*)\2\s*]|[-\w$]+/g;
     let a;
     while (a = reg.exec(path)) {
         res.push(a[1] || a[3] || a[0]);

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -369,6 +369,26 @@ describe('for array indexes', () => {
             value: 3
         });
     });
+	  it('must support negative indexes', () => {
+				const t1 = ['a', 'b', 'c', 'd'];
+				expect(resolve(t1, [-2])).to.eql({
+						chain: [-2],
+						scope: t1,
+						options: undefined,
+						idx: 0,
+						exists: true,
+						value: 'c',
+				}); 
+				const t2 = ['a', ['b', ['c', 'd']]];
+				expect(resolve(t2, [-1, -1, -2])).to.eql({
+						chain: [-1, -1, -2],
+						scope: t2,
+						options: undefined,
+						idx: 2,
+						exists: true,
+						value: 'c',
+				});
+		});
 });
 
 describe('tokenizePath', () => {
@@ -381,6 +401,7 @@ describe('tokenizePath', () => {
         expect(tokenizePath('_')).to.eql(['_']); // underscore
         expect(tokenizePath('$')).to.eql(['$']); // dollar
         expect(tokenizePath('0')).to.eql(['0']); // zero
+        expect(tokenizePath('-1')).to.eql(['-1']); // negative one 
     });
     it('must handle a simple path', () => {
         expect(tokenizePath('a.b.c')).to.eql(['a', 'b', 'c']);
@@ -388,6 +409,7 @@ describe('tokenizePath', () => {
     });
     it('must handle simple indexes', () => {
         expect(tokenizePath('[0]')).to.eql(['0']);
+        expect(tokenizePath('[-1]')).to.eql(['-1']);
         expect(tokenizePath('[0][1][2]')).to.eql(['0', '1', '2']);
         expect(tokenizePath('["a"]')).to.eql(['a']);
         expect(tokenizePath('["abc"]')).to.eql(['abc']);


### PR DESCRIPTION
Hello,

I came across this package today after looking at some alternatives and not being satisfied with them. However, I needed to support negative array indexes for my use case so I patched that in using `Array.prototype.at()` which gives that functionality without hassling with length checking. This shouldn't add any overhead or performance impact aside from a single additional `if(Array.isArray(value))` check.

I also added a few tests to cover this case.
